### PR TITLE
Add support for ACME External Account Binding when registering accounts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
   Previously, the first route to generate a certificate would "win",
   and all matching routes would use that certificate until renewal,
   even if they were configured to use a different provider.
+- Added support for ACME External Account Binding via the `ACME_EAB_KID`
+  and `ACME_EAB_HMAC` settings. This allows Centauri to use providers
+  (such as ZeroSSL) that require accounts to be bound to existing
+  credentials at the provider.
 
 ## 2.6.1 - 2026-05-09
 
@@ -346,7 +350,7 @@ version bump._
 
 ### Other changes
 
-- Fixed issue with build process. No code changes. 
+- Fixed issue with build process. No code changes.
 
 ## 0.4.0 - 2023-08-28
 
@@ -384,7 +388,7 @@ version bump._
 - Lego updated to v4.12.0
 - Tailscale updated to v1.42.0
 
-## 0.2.0 - 2023-01-26 
+## 0.2.0 - 2023-01-26
 
 ### Features
 

--- a/certificate/supplier_lego.go
+++ b/certificate/supplier_lego.go
@@ -30,6 +30,7 @@ import (
 // registrar is the surface we use to interact with lego's account registration API.
 type registrar interface {
 	Register(ctx context.Context, options registration.RegisterOptions) (*acme.ExtendedAccount, error)
+	RegisterWithExternalAccountBinding(ctx context.Context, options registration.RegisterEABOptions) (*acme.ExtendedAccount, error)
 }
 
 // certifier is the surface we use to interact with lego's certificate issuance API.
@@ -44,6 +45,10 @@ type acmeUser struct {
 	email   string
 	account *acme.ExtendedAccount
 	key     crypto.Signer
+	// eabKid and eabHmac hold optional External Account Binding credentials. They are only used at
+	// registration time and are deliberately not persisted to disk.
+	eabKid  string
+	eabHmac string
 }
 
 // savedUser is the on-disk representation of an acmeUser, compatible with the legacy lego v4 format.
@@ -109,10 +114,27 @@ func (a *acmeUser) load(path string) error {
 }
 
 // registerAndSave registers the user with the given ACME registration service, and on successful registration
-// serialises the user information to disk at the specified path.
+// serialises the user information to disk at the specified path. If the user has both EAB credentials set, the
+// account is registered using External Account Binding, as required by some ACME providers (e.g. ZeroSSL).
 func (a *acmeUser) registerAndSave(ctx context.Context, registrar registrar, path string) error {
-	slog.Info("Registering user", "email", a.email)
-	reg, err := registrar.Register(ctx, registration.RegisterOptions{TermsOfServiceAgreed: true})
+	var reg *acme.ExtendedAccount
+	var err error
+
+	switch {
+	case a.eabKid != "" && a.eabHmac != "":
+		slog.Info("Registering user with external account binding", "email", a.email)
+		reg, err = registrar.RegisterWithExternalAccountBinding(ctx, registration.RegisterEABOptions{
+			TermsOfServiceAgreed: true,
+			Kid:                  a.eabKid,
+			HmacEncoded:          a.eabHmac,
+		})
+	case a.eabKid != "" || a.eabHmac != "":
+		return fmt.Errorf("external account binding requires both a key ID and an HMAC key")
+	default:
+		slog.Info("Registering user", "email", a.email)
+		reg, err = registrar.Register(ctx, registration.RegisterOptions{TermsOfServiceAgreed: true})
+	}
+
 	if err != nil {
 		return fmt.Errorf("unable to register new account: %w", err)
 	}
@@ -160,11 +182,15 @@ type LegoSupplierConfig struct {
 	DnsProvider challenge.Provider
 	// DisablePropagationCheck instructs the lego client to not bother checking for DNS propagation.
 	DisablePropagationCheck bool
+	// EabKid is the key ID for External Account Binding, required by some ACME providers (e.g. ZeroSSL).
+	EabKid string
+	// EabHmac is the base64url-encoded HMAC key for External Account Binding.
+	EabHmac string
 }
 
 // NewLegoSupplier creates a new supplier, registering or retrieving an account with the ACME server as necessary.
 func NewLegoSupplier(ctx context.Context, config *LegoSupplierConfig) (*LegoSupplier, error) {
-	user := &acmeUser{email: config.Email}
+	user := &acmeUser{email: config.Email, eabKid: config.EabKid, eabHmac: config.EabHmac}
 	if err := user.load(config.Path); err != nil {
 		return nil, err
 	}

--- a/certificate/supplier_lego_test.go
+++ b/certificate/supplier_lego_test.go
@@ -70,14 +70,21 @@ func Test_acmeUser_load_restoresSavedKey(t *testing.T) {
 }
 
 type fakeRegistrar struct {
-	res  *acme.ExtendedAccount
-	err  error
-	opts registration.RegisterOptions
+	res     *acme.ExtendedAccount
+	err     error
+	opts    registration.RegisterOptions
+	eabOpts registration.RegisterEABOptions
+	eabErr  error
 }
 
 func (f *fakeRegistrar) Register(ctx context.Context, options registration.RegisterOptions) (*acme.ExtendedAccount, error) {
 	f.opts = options
 	return f.res, f.err
+}
+
+func (f *fakeRegistrar) RegisterWithExternalAccountBinding(ctx context.Context, options registration.RegisterEABOptions) (*acme.ExtendedAccount, error) {
+	f.eabOpts = options
+	return f.res, f.eabErr
 }
 
 func Test_acmeUser_registerAndSave_errorsIfRegistrarErrors(t *testing.T) {
@@ -119,6 +126,35 @@ func Test_acmeUser_registerAndSave_writesDetailsToDisk(t *testing.T) {
 	newUser := &acmeUser{}
 	require.NoError(t, newUser.load(path))
 	assert.Equal(t, user, newUser)
+}
+
+func Test_acmeUser_registerAndSave_usesExternalAccountBinding(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "user.json")
+	r := &fakeRegistrar{
+		res: &acme.ExtendedAccount{Location: "https://example.com/acme/reg/1"},
+	}
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	user := &acmeUser{key: privateKey, eabKid: "kid-123", eabHmac: "hmac-456"}
+	require.NoError(t, user.registerAndSave(t.Context(), r, path))
+	assert.True(t, r.eabOpts.TermsOfServiceAgreed)
+	assert.Equal(t, "kid-123", r.eabOpts.Kid)
+	assert.Equal(t, "hmac-456", r.eabOpts.HmacEncoded)
+}
+
+func Test_acmeUser_registerAndSave_errorsIfOnlyKidProvided(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "user.json")
+	r := &fakeRegistrar{res: &acme.ExtendedAccount{}}
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	user := &acmeUser{key: privateKey, eabKid: "kid-123"}
+	assert.Error(t, user.registerAndSave(t.Context(), r, path))
+}
+
+func Test_acmeUser_registerAndSave_errorsIfOnlyHmacProvided(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "user.json")
+	r := &fakeRegistrar{res: &acme.ExtendedAccount{}}
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	user := &acmeUser{key: privateKey, eabHmac: "hmac-456"}
+	assert.Error(t, user.registerAndSave(t.Context(), r, path))
 }
 
 type fakeCertifier struct {

--- a/cmd/centauri/certs.go
+++ b/cmd/centauri/certs.go
@@ -27,6 +27,8 @@ var (
 	acmeEmail              = flag.String("acme-email", "", "Email address for ACME account")
 	acmeDirectory          = flag.String("acme-directory", lego.DirectoryURLLetsEncrypt, "ACME directory to use")
 	acmeProfile            = flag.String("acme-profile", "", "Profile to use when requesting a certificate")
+	acmeEabKid             = flag.String("acme-eab-kid", "", "Key ID for ACME External Account Binding (required by some providers, e.g. ZeroSSL)")
+	acmeEabHmac            = flag.String("acme-eab-hmac", "", "Base64url-encoded HMAC key for ACME External Account Binding")
 	acmeDisablePropagation = flag.Bool("acme-disable-propagation-check", false, "Prevents the ACME client from checking that DNS propagation was successful")
 	wildcardDomains        = flag.String("wildcard-domains", "", "Space separated list of wildcard domains")
 	useStaples             = flag.Bool("ocsp-stapling", false, "Enable OCSP response stapling")
@@ -79,6 +81,8 @@ func createLegoSupplier() (*certificate.LegoSupplier, error) {
 			DnsProvider:             dnsProvider,
 			DisablePropagationCheck: *acmeDisablePropagation,
 			Profile:                 *acmeProfile,
+			EabKid:                  *acmeEabKid,
+			EabHmac:                 *acmeEabHmac,
 		},
 	)
 	if err != nil {

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -323,6 +323,23 @@ The URL of the ACME directory to obtain certificates from.
 For testing, change to the Let's Encrypt staging environment,
 which has more generous rate limits: `https://acme-staging-v02.api.letsencrypt.org/directory`.
 
+### `ACME_EAB_KID`
+
+- **Default**: -
+
+The key ID to use for External Account Binding. Some ACME providers (such as
+ZeroSSL) require accounts to be bound to an existing account at the provider,
+and will reject registration with an `externalAccountRequired` error unless
+this is supplied. Must be set together with `ACME_EAB_HMAC`.
+
+### `ACME_EAB_HMAC`
+
+- **Default**: -
+
+The base64url-encoded HMAC key to use for External Account Binding. Must be
+set together with `ACME_EAB_KID`. See your ACME provider's documentation for
+how to obtain these credentials.
+
 ### `ACME_DISABLE_PROPAGATION_CHECK`
 
 - **Default**: `false`


### PR DESCRIPTION
Add support for ACME External Account Binding when registering accounts.

Adds 2 new env vars/flags:

- `ACME_EAB_KID`
- `ACME_EAB_HMAC`

Which can then be used when using an alternative ACME provider than LetsEncrypt (eg ZeroSSL)

I've got a docker image compiled with this PR at `registry.shanemcc.net/public/csmith-centauri:latest` and it seems to work.

<img width="485" height="322" alt="image" src="https://github.com/user-attachments/assets/736766e9-81f5-4943-a765-edc7b804e664" />